### PR TITLE
Add additional InMemoryContentStore with cache eviction capabilities.

### DIFF
--- a/src/HttpCache/HttpCache.csproj
+++ b/src/HttpCache/HttpCache.csproj
@@ -67,6 +67,8 @@
     <Compile Include="InMemoryContentStore.cs" />
     <Compile Include="CacheKey.cs" />
     <Compile Include="HttpCacheHandler.cs" />
+    <Compile Include="InMemoryContentStoreWithEviction.cs" />
+    <Compile Include="LruCollection.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/HttpCache/InMemoryContentStoreWithEviction.cs
+++ b/src/HttpCache/InMemoryContentStoreWithEviction.cs
@@ -1,0 +1,133 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Tavis.HttpCache
+{
+    public class InMemoryContentStoreWithEviction : IContentStore
+    {
+        private readonly object syncRoot = new object();
+        private readonly Dictionary<CacheKey, CacheEntryContainer> _CacheContainers = new Dictionary<CacheKey, CacheEntryContainer>();
+        private readonly Dictionary<Guid, HttpResponseMessage> _responseCache = new Dictionary<Guid, HttpResponseMessage>();
+
+        private int CacheCapacity = 1000;
+        private LruCollection<CacheKey> _lruCollection = new LruCollection<CacheKey>();
+
+        public InMemoryContentStoreWithEviction(int cacheCapacity)
+        {
+            CacheCapacity = cacheCapacity;
+        }
+
+        public async Task<IEnumerable<CacheEntry>> GetEntriesAsync(CacheKey cacheKey)
+        {
+            if (_CacheContainers.ContainsKey(cacheKey))
+            {
+                return _CacheContainers[cacheKey].Entries;
+            }
+            return null;
+        }
+
+        public async Task<HttpResponseMessage> GetResponseAsync(Guid variantId)
+        {
+            return await CloneResponseAsync(_responseCache[variantId]).ConfigureAwait(false);
+        }
+
+        public async Task AddEntryAsync(CacheEntry entry, HttpResponseMessage response)
+        {
+            CacheEntryContainer cacheEntryContainer = GetOrCreateContainer(entry.Key);
+            lock (syncRoot)
+            {
+                _lruCollection.AddOrUpdate(entry.Key);
+                cacheEntryContainer.Entries.Add(entry);
+                _responseCache[entry.VariantId] = response;
+
+                if (IsCacheFull())
+                {
+                    RemoveOldestItemFromCache();
+                }
+            }
+        }
+
+        private bool IsCacheFull()
+        {
+            if (_responseCache.Count >= CacheCapacity)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private void RemoveOldestItemFromCache()
+        {
+            var cacheKey = _lruCollection.Pop();
+            CacheEntryContainer entry;
+            var exists = _CacheContainers.TryGetValue(cacheKey, out entry);
+            if (exists)
+            {
+                foreach (var item in entry.Entries)
+                {
+                    _responseCache.Remove(item.VariantId);
+                }
+                _CacheContainers.Remove(cacheKey);
+            }
+        }
+
+        public async Task UpdateEntryAsync(CacheEntry entry, HttpResponseMessage response)
+        {
+
+            CacheEntryContainer cacheEntryContainer = GetOrCreateContainer(entry.Key);
+
+            lock (syncRoot)
+            {
+                var oldentry = cacheEntryContainer.Entries.First(e => e.VariantId == entry.VariantId);
+                cacheEntryContainer.Entries.Remove(oldentry);
+                cacheEntryContainer.Entries.Add(entry);
+                _responseCache[entry.VariantId] = response;
+
+                _lruCollection.AddOrUpdate(entry.Key);
+            }
+        }
+
+        private CacheEntryContainer GetOrCreateContainer(CacheKey key)
+        {
+            CacheEntryContainer cacheEntryContainer;
+
+            if (!_CacheContainers.ContainsKey(key))
+            {
+                cacheEntryContainer = new CacheEntryContainer(key);
+                lock (syncRoot)
+                {
+                    _CacheContainers[key] = cacheEntryContainer;
+                }
+            }
+            else
+            {
+                cacheEntryContainer = _CacheContainers[key];
+            }
+            return cacheEntryContainer;
+        }
+
+        private async Task<HttpResponseMessage> CloneResponseAsync(HttpResponseMessage response)
+        {
+            var newResponse = new HttpResponseMessage(response.StatusCode);
+            var ms = new MemoryStream();
+
+            foreach (var v in response.Headers) newResponse.Headers.TryAddWithoutValidation(v.Key, v.Value);
+
+
+            if (response.Content != null)
+            {
+                await response.Content.CopyToAsync(ms).ConfigureAwait(false);
+                ms.Position = 0;
+                newResponse.Content = new StreamContent(ms);
+                foreach (var v in response.Content.Headers) newResponse.Content.Headers.TryAddWithoutValidation(v.Key, v.Value);
+            }
+
+            return newResponse;
+        }
+    }
+}

--- a/src/HttpCache/LruCollection.cs
+++ b/src/HttpCache/LruCollection.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Tavis.HttpCache;
+
+namespace Tavis.HttpCache
+{
+    public class LruCollection<T>
+    {
+        private readonly SortedDictionary<long, T> _sortedElementDictionary = new SortedDictionary<long, T>();
+        private readonly Dictionary<T, long> _elementToIdx = new Dictionary<T, long>();
+
+        private long _entryIdx = long.MinValue;
+        public LruCollection() { }
+
+        // Add or update reference
+        public void AddOrUpdate(T element)
+        {
+            if (_elementToIdx.ContainsKey(element))
+            {
+                Update(element);
+            }
+            else
+            {
+                Add(element);
+            }
+        }
+
+        public bool Contains(T element)
+        {
+            return _elementToIdx.ContainsKey(element);
+        }
+
+        private void Add(T element)
+        {
+            _entryIdx = _entryIdx + 1;
+            _sortedElementDictionary.Add(_entryIdx, element);
+            _elementToIdx.Add(element, _entryIdx);
+        }
+
+        private void Update(T element)
+        {
+            var oldIdx = _elementToIdx[element];
+            _sortedElementDictionary.Remove(oldIdx);
+
+            _entryIdx = _entryIdx + 1;
+            _sortedElementDictionary[_entryIdx] = element;
+            _elementToIdx[element] = _entryIdx;
+        }
+
+        // Remove least recently used reference
+        public T Pop()
+        {
+            if (_sortedElementDictionary.Count == 0)
+            {
+                return default(T);
+            }
+
+            var oldestEntry = _sortedElementDictionary.First();
+            var element = oldestEntry.Value;
+            var oldIdx = oldestEntry.Key;
+
+            _sortedElementDictionary.Remove(oldIdx);
+            _elementToIdx.Remove(element);
+
+            return element;
+        }
+
+    }
+}

--- a/src/HttpCacheTests/HttpCacheTests.csproj
+++ b/src/HttpCacheTests/HttpCacheTests.csproj
@@ -78,6 +78,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CachingControllers.cs" />
+    <Compile Include="LruCollectionTest.cs" />
     <Compile Include="RequestDirectiveTests.cs" />
     <Compile Include="ResponseDirectiveTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/HttpCacheTests/LruCollectionTest.cs
+++ b/src/HttpCacheTests/LruCollectionTest.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using Tavis.HttpCache;
+using Xunit;
+
+namespace HttpCacheTests
+{
+    public class LruCollectionTest
+    {
+
+        [Fact]
+        public void Should_pop_elements_in_order_of_insertion()
+        {
+            var lruCollection = new LruCollection<string>();
+
+            var first = "1";
+            var second = "2";
+            var third = "3";
+
+            lruCollection.AddOrUpdate(first);
+            lruCollection.AddOrUpdate(second);
+            lruCollection.AddOrUpdate(third);
+
+            var popped1 = lruCollection.Pop();
+            var popped2 = lruCollection.Pop();
+            var popped3 = lruCollection.Pop();
+
+            Assert.Equal(first, popped1);
+            Assert.Equal(second, popped2);
+            Assert.Equal(third, popped3);
+        }
+
+        [Fact]
+        public void Should_pop_elements_in_order_of_insertion_and_update()
+        {
+            var lruCollection = new LruCollection<string>();
+
+            var first = "1";
+            var second = "2";
+            var third = "3";
+
+            lruCollection.AddOrUpdate(first);
+            lruCollection.AddOrUpdate(second);
+            lruCollection.AddOrUpdate(third);
+
+            // Update before popping
+            lruCollection.AddOrUpdate(first);
+
+            var popped1 = lruCollection.Pop();
+            var popped2 = lruCollection.Pop();
+            var popped3 = lruCollection.Pop();
+
+            Assert.Equal(second, popped1);
+            Assert.Equal(third, popped2);
+            Assert.Equal(first, popped3);
+        }
+
+        [Fact]
+        public void Should_return_null_if_lru_is_empy()
+        {
+            var lruCollection = new LruCollection<string>();
+            var popped = lruCollection.Pop();
+            Assert.Null(popped);
+        }
+
+        [Fact]
+        public void Should_return_true_if_collection_contains_element()
+        {
+            var lruCollection = new LruCollection<string>();
+            lruCollection.AddOrUpdate("1");
+            Assert.True(lruCollection.Contains("1"));
+        }
+
+        [Fact]
+        public void Should_return_flase_if_collection_doesnt_contain_element()
+        {
+            var lruCollection = new LruCollection<string>();
+            Assert.False(lruCollection.Contains("1"));
+        }
+    }
+}


### PR DESCRIPTION
For when you need rough control of your memory footprint. The eviction is based on item count, not cache size, but it should be enough to avoid filling memory in most cases.